### PR TITLE
Allow specifying a custom WebSocket constructor

### DIFF
--- a/generate-client.ts
+++ b/generate-client.ts
@@ -114,7 +114,7 @@ export namespace Aqueduct {
   /**
    * Initialize the Aqueduct client. Required to use the client.
    */
-  export const Initialize = (params?: { host?: string; apiKeyId?: string; }) => {
+  export const Initialize = (params?: { host?: string; apiKeyId?: string; webSocketCtor?: any }) => {
     const hasProcess = typeof process !== 'undefined' && process.env;
     const host = (params && params.host) || (hasProcess && process.env.AQUEDUCT_HOST) || 'api.ercdex.com';
     baseApiUrl = \`https://\${host}\`;
@@ -127,13 +127,17 @@ export namespace Aqueduct {
       process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0 as any;
     }
 
-    hasWebSocket = typeof WebSocket !== 'undefined';
-    if (!hasWebSocket) {
-      console.warn('No WebSocket found in global namespace; subscriptions will not be configured.');
-      return;
-    }
+    if (params && params.webSocketCtor) {
+      socket = new params.webSocketCtor(\`wss:\${host}\`, undefined);
+    }else{
+      hasWebSocket = typeof WebSocket !== 'undefined';
+      if (!hasWebSocket) {
+        console.warn('No WebSocket found in global namespace; subscriptions will not be configured.');
+        return;
+      }
 
-    socket = new ReconnectingWebsocket(\`wss:\${host}\`, undefined);
+      socket = new ReconnectingWebsocket(\`wss:\${host}\`, undefined);
+    }
 
     socket.onopen = () => {
       Object.keys(subscriptions).map(k => subscriptions[k]).forEach(s => {

--- a/generate-client.ts
+++ b/generate-client.ts
@@ -128,6 +128,7 @@ export namespace Aqueduct {
     }
 
     if (params && params.webSocketCtor) {
+      hasWebSocket = true
       socket = new params.webSocketCtor(\`wss:\${host}\`, undefined);
     }else{
       hasWebSocket = typeof WebSocket !== 'undefined';

--- a/src/generated/aqueduct.ts
+++ b/src/generated/aqueduct.ts
@@ -55,6 +55,7 @@ export namespace Aqueduct {
     }
 
     if (params && params.webSocketCtor) {
+      hasWebSocket = true
       socket = new params.webSocketCtor(`wss:${host}`, undefined);
     }else{
       hasWebSocket = typeof WebSocket !== 'undefined';


### PR DESCRIPTION
This is a fix to bypass the behaviour of reconnecting-websocket, which doesn't behave exactly like a normal WebSocket. Specifically `onopen` doesn't work.

This PR adds support for supplying a custom socket constructor so we can use uws or ws.